### PR TITLE
Changes I used to build mmj2 for Ubuntu 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 classes/
 /bin
+mmj2.jar
+MANIFEST.MF

--- a/INSTALL.html
+++ b/INSTALL.html
@@ -317,6 +317,13 @@ right-mouse click the <code>Command Prompt</code> menu item and select
 Shortcut</code>" so that a Command Prompt desktop icon is conveniently
 available on the Windows desktop for future use.)<br>
 <br>
+- If you got mmj2 from git, enter this command to get code which mmj2
+depends on:<br>
+<code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span
+ style="font-weight: bold;">git submodule init</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span
+ style="font-weight: bold;">git submodule update</span></code><br>
+<br>
 - Enter this command to compile the mmj2 source code:<br>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span

--- a/compile/linux/compilescript.txt
+++ b/compile/linux/compilescript.txt
@@ -12,4 +12,4 @@ echo "Manifest-Version: 1.0" >MANIFEST.MF
 echo "Main-Class: mmj.util.BatchMMJ2" >>MANIFEST.MF
 cd src && javac `find -name *.java` -d ../classes && cd ../classes && \
 jar cfm ../mmj2.jar ../MANIFEST.MF \
-`find -name "*.class" | sed -e "s/^\.\///"
+`find -name "*.class" | sed -e "s/^\.\///"`

--- a/compile/linux/compilescript.txt
+++ b/compile/linux/compilescript.txt
@@ -10,6 +10,7 @@
 #
 echo "Manifest-Version: 1.0" >MANIFEST.MF
 echo "Main-Class: mmj.util.BatchMMJ2" >>MANIFEST.MF
-cd src && javac `find -name *.java` -d ../classes && cd ../classes && \
+cd src && javac `find . ../lib -name *.java` -d ../classes && \
+cd ../classes && \
 jar cfm ../mmj2.jar ../MANIFEST.MF \
 `find -name "*.class" | sed -e "s/^\.\///"`

--- a/src/mmj/util/BatchMMJ2.java
+++ b/src/mmj/util/BatchMMJ2.java
@@ -125,9 +125,10 @@ public class BatchMMJ2 extends BatchFramework {
         final String javaVersion = System
             .getProperty(UtilConstants.JAVA_VERSION_PROPERTY_NAME);
 
-        final int maj = Integer.parseInt(javaVersion.substring(0, 1));
+        final String[] versionComponents = javaVersion.split("\\.");
+        final int maj = Integer.parseInt(versionComponents[0]);
 
-        final int min = Integer.parseInt(javaVersion.substring(2, 3));
+        final int min = Integer.parseInt(versionComponents[1]);
 
         if (maj < UtilConstants.JAVA_VERSION_MMJ2_MAJ
             || maj == UtilConstants.JAVA_VERSION_MMJ2_MAJ


### PR DESCRIPTION
This is using the java shipped with Ubuntu (`10.0.2+13-Ubuntu-1ubuntu0.18.04.1` it calls itself).

The change to `src/mmj/util/BatchMMJ2.java` is the way in which this version of java differs from older ones. The other changes were how I got mmj2 to build (there may be other techniques out there).
