### PR TITLE
Tutorial: Add missing colons, rename Q to QZ

### DIFF
--- a/mmj2jar/PATutorial/Page301.mmp
+++ b/mmj2jar/PATutorial/Page301.mmp
@@ -5,11 +5,12 @@ $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=a2i
      - Hypothesis Step Numbers are prefixed with 'h'
      - Step Numbers are not in numeric order(!), but are unique
      - Ref Labels are blank
-     - Trailing ":"s are optional, for your convenience
+     - If there is just one colon in this field, it's assumed to be "Step:Ref"
+       (older versions of mmj2 assumed it was Step:Hyp)
      - Blanks are not permitted inside a "Step:Hyp:Ref" (making things
-       easier for the programmers)
+       easier for the mmj2 programmers)
      - the final step "number" is "qed" (also for the convenience of
-       the programmer...)
+       the mmj2 programmers...)
 
  OK, now press Ctrl-U and see what happens to the Step:Hyp:Ref fields.
  (Use Edit/Undo -- twice -- to retry and look again.)
@@ -17,9 +18,9 @@ $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=a2i
 h1000              |- ( ph -> ps )
 h200               |- ( ps -> ch )
 h30                |- ( ch -> th ) 
-3:200              |- ( ph -> ( ps -> ch ) )
-4:3                |- ( ( ph -> ps ) -> ( ph -> ch ) )
-qed:1000,4         |- ( ph -> ch )
+3:200:             |- ( ph -> ( ps -> ch ) )
+4:3:               |- ( ( ph -> ps ) -> ( ph -> ch ) )
+qed:1000,4:        |- ( ph -> ch )
 
 *OK, proceed to the next Tutorial page (Page302.mmp)!
 $) 

--- a/mmj2jar/PATutorial/Page302.mmp
+++ b/mmj2jar/PATutorial/Page302.mmp
@@ -5,8 +5,8 @@ $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=a2i
 h1000              |- ( ph -> ps )
 h200               |- ( ps -> ch )
 h30                |- ( ch -> th ) 
-3:200              |- ( ph -> ( ps -> ch ) )
-4:3                |- ( ( ph -> ps ) -> ( ph -> ch ) )
+3:200:             |- ( ph -> ( ps -> ch ) )
+4:3:               |- ( ( ph -> ps ) -> ( ph -> ch ) )
 qed:1000,4:ax-mp   |- ( ph -> ch )
 
 *Notice that the Unification process modified the Step:Hyp:Ref

--- a/mmj2jar/PATutorial/Page303.mmp
+++ b/mmj2jar/PATutorial/Page303.mmp
@@ -5,9 +5,9 @@ $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=a2i
 h1000              |- ( ph -> ps )
 h200               |- ( ps -> ch )
 h30                |- ( ch -> th ) 
-3:200              |- ( ph -> ( ps -> ch ) )
-4:3                |- ( ( ph -> ps ) -> ( ph -> ch ) )
-qed:1000,4         |- ( ph -> ch )
+3:200:             |- ( ph -> ( ps -> ch ) )
+4:3:               |- ( ( ph -> ps ) -> ( ph -> ch ) )
+qed:1000,4:        |- ( ph -> ch )
 
 *There are two IMPORTANT things to NOTICE in the proof steps above:
      - Hypothesis Step 30 is redundant. It serves no purpose except

--- a/mmj2jar/PATutorial/Page304.mmp
+++ b/mmj2jar/PATutorial/Page304.mmp
@@ -9,9 +9,9 @@ $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=
 h1000              |- ( ph -> ps )
 h200               |- ( ps -> ch )
 h30                |- ( ch -> th ) 
-3:200              |- ( ph -> ( ps -> ch ) )
-4:3                |- ( ( ph -> ps ) -> ( ph -> ch ) )
-qed:200,1000       |- ( ph -> ch )
+3:200:             |- ( ph -> ( ps -> ch ) )
+4:3:               |- ( ( ph -> ps ) -> ( ph -> ch ) )
+qed:200,1000:      |- ( ph -> ch )
 
 *Notice that:
      - Because the LOC_AFTER field is blank, sylClone is logically

--- a/mmj2jar/PATutorial/Page412.mmp
+++ b/mmj2jar/PATutorial/Page412.mmp
@@ -1,4 +1,4 @@
-$( <MM> <PROOF_ASST> THEOREM=Q  LOC_AFTER=
+$( <MM> <PROOF_ASST> THEOREM=QZ LOC_AFTER=
 *                                                          Page412.mmp
  In the previous "reiteration" proof example we double-clicked the
  'qed' step to invoke the Step Selector Dialog to see all possible
@@ -12,15 +12,15 @@ $( <MM> <PROOF_ASST> THEOREM=Q  LOC_AFTER=
  with the Step Selector and you have a top-down, bottom-up or even
  middle-out "search matrix"!
 
- In this example -- theorem "Q" -- double-click any derivation step:
+ In this example -- theorem "QZ" -- double-click any derivation step:
     - Step 100: find all unifying Assertions using both Hypotheses (a
       "top down" search);
     - Step 200...an example of working from the middle out;
     - Step 'qed': find unifying Assertions with 1 or more hypotheses,
       including step 200 ("bottom up" search).
  
-h1::Q.1       |- ( ph -> ( ps -> ch ) )
-h2::Q.2       |- ( ph -> ( ps -> -. ch ) )
+h1::QZ.1       |- ( ph -> ( ps -> ch ) )
+h2::QZ.2       |- ( ph -> ( ps -> -. ch ) )
 
 100:1,2:      |- &W1
 


### PR DESCRIPTION
In the tutorial, fix several of the chapter 3 pages
so that missing colons are added (otherwise the tutorial
doesn't work properly because mmj2 now interprets them differently).

Also, rename "Q" to "QZ" because "Q" conflicts with an existing symbol
(otherwise Page412 won't work).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>