### PR TITLE
Tutorial: Large number of improvements

### DIFF
--- a/mmj2jar/PATutorial/Page102.mmp
+++ b/mmj2jar/PATutorial/Page102.mmp
@@ -8,10 +8,11 @@ $( <MM> <PROOF_ASST> THEOREM=welcome  LOC_AFTER=a1i
  Non-Comment Proof Worksheet Statements are distinguished
  by specific tokens beginning in column 1:
      - Header ("$(" in line 1 above);
+     - Comment ("*")
      - Distinct Variable ("$d" in line 20 below);
      - Hypothesis Step ("h1" and "h2" in lines 21 and 22 below);
      - Derivation Step ("1", "2", ..., n, or "qed" -- line 23 below);
-     - Footer ("$)" always the last line of the Proof Worksheet); and
+     - Footer ("$)", always the last line of the Proof Worksheet); and
      - Generated Proof ("$=" -- to see one of these, press Ctrl-U or
                         select Menu Item "Unify/Unify (check Proof)"
 

--- a/mmj2jar/PATutorial/Page103.mmp
+++ b/mmj2jar/PATutorial/Page103.mmp
@@ -10,7 +10,7 @@ $( <MM> <PROOF_ASST> THEOREM=welcome  LOC_AFTER=ax-mp
  The ProofAsstGUI program knows nothing about proofs, math or logic.
  It is just a basic text editor with extra features. You enter and
  update proof text, then use the "Unify" menu to check your work! And
- that is the point of the whole thing (the other menus are fun too...)
+ that is the point of the whole thing (the other menus are fun too...).
 
  The mmj2 ProofAsstGUI does not even update its input Metamath .mm
  database file(s)! You have to do that manually or with the Metamath
@@ -37,4 +37,3 @@ $( <MM> <PROOF_ASST> THEOREM=welcome  LOC_AFTER=ax-mp
 
 qed:         |- ( -. -. ph -> ph )
 $)
-

--- a/mmj2jar/PATutorial/Page201.mmp
+++ b/mmj2jar/PATutorial/Page201.mmp
@@ -4,11 +4,12 @@ $( <MM> <PROOF_ASST> THEOREM=aProofLabel  LOC_AFTER=
 
 qed::         |- ( ph -> ( ph -> ph ) )
 
-*In mmj2 everything we prove is called a "theorem". Every Assertion
- is either an Axiom or a Theorem. Metamath nomenclature distinguishes
- between "inferences", which have Logical Hypotheses (called
- "Essential Hypotheses" in Metamath), and "theorems" which (usually)
- have none.
+*In Metamath every assertion is either an axiom
+ (a statement we assume to be true) or a provable assertion
+ (a statement we can prove from axioms and other provable assertions).
+ For our purposes, "theorem" is a synonym for
+ "provable assertion". The purpose of mmj2 is to help people create
+ proofs of thoerems.
 
  In the Header Statement (line 1) we are naming the theorem with
  label "aProofLabel". Since the theorem is new the label name must not
@@ -20,4 +21,3 @@ qed::         |- ( ph -> ( ph -> ph ) )
  Then go to the next Tutorial page (Page202.mmp).
 
 $)
-

--- a/mmj2jar/PATutorial/Page202.mmp
+++ b/mmj2jar/PATutorial/Page202.mmp
@@ -8,7 +8,9 @@ qed::         |- ( ph -> ( ph -> ph ) )
  proof: the "Ref" (Reference) label, ax-1, that justifies the "qed"
  step. And then, because the proof is valid, it generates the Metamath
  RPN-format proof, ready for copying into the input .mm Metamath
- database file!
+ database file! You can tell that because the status screen says
+ "RPN-format Metamath proof generated!", and at the end of the
+ worksheet there is a $= ... statement with a compressed proof.
 
  But what just happened, really?
 
@@ -17,7 +19,7 @@ qed::         |- ( ph -> ( ph -> ph ) )
 
      "|- ( ph -> ( ph -> ph ) )"
 
- And it found ax-1, the first Axiom in set.mm! This is one of the
+ And it found ax-1, the first Axiom in set.mm. This is one of the
  shortest possible proofs. Just one step!
 
  Our theorem, aProofLabel, unifies with ax-1 because it matches the
@@ -47,7 +49,8 @@ qed::         |- ( ph -> ( ph -> ph ) )
  unify is generally quick after that.
 
  Now, as an experiment, in the "LOC_AFTER" field in the Header enter
- "wi", so that you see this "LOC_AFTER=wi". Then press Ctrl-U and
+ "wi", so that you see this "LOC_AFTER=wi". Do *not* erase the use of
+ "ax-1" - leave that be. Then press Ctrl-U and
  watch what happens! Then go to the next Tutorial page (Page203.mmp).
 
 $)

--- a/mmj2jar/PATutorial/Page204.mmp
+++ b/mmj2jar/PATutorial/Page204.mmp
@@ -18,7 +18,7 @@ qed::         |- ( ph -> ( ph -> ph ) )
  does not already have a position, then the logical position of the theorem
  would be at the end of the Metamath database. This is an important
  point because a proof may only refer to symbols and labels that are
- located prior to it in the Metamath database (to prevent
+ located prior to it in the Metamath database (this prevents
  circular reasoning).
 
  Thus, this proof is only allowed to use the contents of the database

--- a/mmj2jar/PATutorial/Page301.mmp
+++ b/mmj2jar/PATutorial/Page301.mmp
@@ -1,25 +1,7 @@
 $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=a2i
 *                                                          Page301.mmp
- Have a careful look at the "Step:Hyp:Ref" field at the start of each
- proof step below. Notice especially how:
-     - Hypothesis Step Identifiers are prefixed with 'h'.
-       The 'h' is not considered part of the step identifier.
-       Notice that you do not have to include the latter two fields
-       (the "hyp" part must be empty for hypotheses - hypotheses
-       can't have hypotheses)
-     - Step Identifiers must be unique, and are often numbered,
-       but they are not necessarily in numeric order (!)
-     - Ref Labels in this example start blank
-     - If there is just one colon in this field, it's assumed to be "Step:Ref"
-       (older versions of mmj2 assumed it was Step:Hyp)
-     - Blanks are not permitted inside a "Step:Hyp:Ref" (this makes things
-       easier for the mmj2 programmers)
-     - The final step identifier (indicating the conclusion
-       to be proved) is always "qed"
-
- OK, now press Ctrl-U (unify) and see what happens to the Step:Hyp:Ref fields.
- Notice that unify fills in a lot of information, producing
- full Step:Hyp:Ref fields.
+ Take a look at the "Step:Hyp:Ref" field at the start of each
+ proof step below:
 
 h1000              |- ( ph -> ps )
 h200               |- ( ps -> ch )
@@ -28,6 +10,28 @@ h30                |- ( ch -> th )
 4:3:               |- ( ( ph -> ps ) -> ( ph -> ch ) )
 qed:1000,4:        |- ( ph -> ch )
 
+* Notice especially how these fields work:
+     - Hypothesis Step Identifiers are prefixed with 'h'.
+       The 'h' is not considered part of the step identifier.
+       Notice that you do not have to include the latter two fields.
+       The "hyp" part must always be empty for hypotheses - hypotheses
+       can't have hypotheses.
+     - Step Identifiers must be unique, and are often numbered,
+       but they are not necessarily in numeric order (!)
+       You can use alphanumerics for step identifiers, but they cannot
+       begin with the letter 'h' (since that indicates a hypothesis).
+     - The final step identifier (indicating the conclusion
+       to be proved) is always "qed"
+     - Ref Labels in this example start blank - mmj2's unify can sometimes
+       fill them in.
+     - If there is just one colon in this field, it's assumed to be "Step:Ref"
+       (older versions of mmj2 assumed it was Step:Hyp)
+     - Blanks are not permitted inside a "Step:Hyp:Ref" (this makes things
+       easier for the mmj2 programmers)
+
+ OK, now press Ctrl-U (unify) and see what happens to the Step:Hyp:Ref fields.
+ Notice that unify fills in a lot of information, producing
+ full Step:Hyp:Ref fields.
+
 *OK, proceed to the next Tutorial page (Page302.mmp)!
 $)
-

--- a/mmj2jar/PATutorial/Page304.mmp
+++ b/mmj2jar/PATutorial/Page304.mmp
@@ -5,7 +5,8 @@ $( <MM> <PROOF_ASST> THEOREM=sylClone  LOC_AFTER=
  erased and its Hyp has been changed to "200,1000", as was
  instructed on the previous page Page303.mmp.
 
- Press Ctrl-U now to Unify the proof.
+ Press Ctrl-U now to Unify the proof; you should see the same results
+ as the end of the last page, where step qed has a reference to "syl".
 
 h1000              |- ( ph -> ps )
 h200               |- ( ps -> ch )
@@ -27,12 +28,15 @@ qed:200,1000:      |- ( ph -> ch )
  include them in the output Metamath RPN-format proof. What this means
  is that you can use the mmj2 Proof Assistant as a scratch pad, or a
  work area. In other words, you can try new steps in the middle of an
- existing proof to experiment with new derivations!
+ existing proof to experiment with new derivations.
 
  Now, just as an experiment, change the "qed" step's Hyp back to
- "1000,4" and erase its Ref "syl". Then press Ctrl-U. Notice that
- syl is not used. That is  because it does not unify with the "qed"
- step anymore, given Hyp field "1000,4". This proves that mmj2 follows
+ "1000,4" and erase its Ref "syl". Make sure you have a colon after
+ "1000,4" or mmj2 will think you are referring to a theorem named
+ "1000,4". Then press Ctrl-U. Notice that syl is not used.
+ That is because it does not unify with the "qed"
+ step anymore, given Hyp field "1000,4". Instead, mmj2 will use ax-mp,
+ because ax-mp is what matches "1000,4". This proves that mmj2 follows
  orders and is not a mind-reader!
 
  OK, forward to the next Tutorial page (Page401.mmp)!

--- a/mmj2jar/PATutorial/Page401.mmp
+++ b/mmj2jar/PATutorial/Page401.mmp
@@ -1,7 +1,7 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
 *                                                          Page401.mmp
  In this section we will go into some of the more interesting features
- of the Proof Assistant, and also, talk about "proofs" in mmj2 and
+ of the mmj2 Proof Assistant, and also, talk about "proofs" in mmj2 and
  Metamath. Press Ctrl-U now to Unify the proof.
 
 h1::reiteration.1  |- ph
@@ -13,13 +13,13 @@ qed::             |- ph
  That's because we've told it that the theorem is "reiteration";
  mmj2 realizes that you probably mean to save it as "reiteration.mmp".
 
- When you pressed Ctrl-U the following "info" message appears: "I-PA-0111
- Theorem reiteration Unification process not started:
- no derivation proof steps are ready for unification.
+ When you pressed Ctrl-U the following "info" message appears:
+ "I-PA-0411 Theorem reiteration: Step qed: Step incomplete.".
 
  The reason for the message is that the Proof Worksheet only has one
- Derivation Step (the "qed" step), and that step has
- a blank hypotheses and a blank reference.
+ Derivation Step (the "qed" step); theorem hypotheses don't count as
+ derivation steps since we don't derive them (they are starting points).
+ In addition, that qed step has a blank hypotheses and a blank reference.
  If a step has no errors, its hypotheses are blank (or include "?"),
  and it has a blank ref field, it is considered merely "incomplete" and
  unification is not attempted for it. However...KEY POINT TO REMEMBER:
@@ -27,16 +27,15 @@ qed::             |- ph
      A Derivation Step is allowed to use an incomplete step,
      and the referring step can be Unified.
 
- That is a very important fact because it allows a proof to be completed
- from the Bottom Up (that is, "proving forwards from known facts
- to the goal").  You can create an incomplete step for use
- as an hypothesis to derive a subsequent step. Then, you can work on
- figuring out how to derive the incomplete step.
+ This allows you to create a part of a proof "forwards", that is,
+ from one claim forwards to some other claim.
 
- The mmj2 Proof Assistant enables work on a proof to proceed Top Down
- ("proving backwards from the goal to known facts"),
- Bottom Up ("proving forwards from known facts to the goal"),
- and any combination thereof. Nice...
+ The mmj2 proof assistant is specifically designed for flexibility.
+ MMj2 lets you prove backwards (from the goal back to known facts), prove
+ forwards (from known facts towards the goal), and prove middle out
+ (prove some statements from other statements, in the hopes that this
+ information will eventually be useful). You can even use any combination
+ of approaches while developing a single proof. Nice!
 
 *OK, forward to the next Tutorial page (Page402.mmp)!
 

--- a/mmj2jar/PATutorial/Page402.mmp
+++ b/mmj2jar/PATutorial/Page402.mmp
@@ -1,5 +1,5 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
-*                                                          Page403.mmp
+*                                                          Page402.mmp
  Press Ctrl-U to Unify the proof as discussed in the last page:
 
 h1::reiteration.1  |- ph

--- a/mmj2jar/PATutorial/Page402.mmp
+++ b/mmj2jar/PATutorial/Page402.mmp
@@ -1,27 +1,25 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
-*                                                          Page402.mmp
+*                                                          Page403.mmp
+ Press Ctrl-U to Unify the proof as discussed in the last page:
+
 h1::reiteration.1  |- ph
-qed::              |- ph
+qed::reiteration.1 |- ph
 
-*This theorem is interesting for several reasons. It has the shortest
- possible Metamath RPN-format proof, "wph". That is the Label of the
- Variable Hypothesis statement in set.mm that refers to wff Variable
- "ph". Another interesting fact is that its proof in Metamath requires
- no Axioms! That's right. It is a built-in feature of the underlying
- Metamath proof language: just pop "wph" onto the stack and Q.E.D.!
+*
+ Oops, this error message is displayed:
+ "E-PA-0348 Theorem reiteration Step qed: Invalid Ref = reiteration.1
+ on derivation proof step. Does not specify a valid statement in the Metamath
+ file that was loaded. ... Proof Text input reader last position ..."
 
- The nearest nearest theorem to "reiteration" in set.mm is called
- "dummylink", which is a technical theorem used by the Metamath
- Export/Import tool, eimm.exe, and should not be used in completed
- proofs. Normally in mmj2 we use the following RunParm to exclude
- "dummylink" from the set of Assertions that can be automatically
- used in Unification:
+ When you see "Proof Text input reader..." that tells you that
+ the error was so severe that processing stopped immediately while
+ initially examining the texgt. The program didn't even attempt Unification.
 
-     "ProofAsstUnifySearchExclude,biigb,xxxid,dummylink"
-
- You might think of setting the "qed" step's Ref = "wph" and pressing
- Ctrl-U to complete the proof. Try that, and see what happens!
+ The problem is that the mmj2 Proof Assistant requires that the Ref
+ Label on a Derivation step refer to an Assertion, not a Hypothesis.
+ This is a limitation of the mmj2 Proof Assistant, and was intended to
+ simplify the programming of mmj2. In practice this isn't a significant
+ limitation.
 
  OK, forward to the next Tutorial page (Page403.mmp)!
-
 $)

--- a/mmj2jar/PATutorial/Page403.mmp
+++ b/mmj2jar/PATutorial/Page403.mmp
@@ -1,28 +1,32 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
-*                                                          Page403.mmp
- Press Ctrl-U to Unify the proof:
-
+*                                                          Page402.mmp
 h1::reiteration.1  |- ph
-qed::wph           |- ph
+qed::              |- ph
 
-*
- Oops, this error message is displayed: "E-PA-0350 Theorem reiteration
- Step qed: Invalid Ref = wph is not an Assertion. A derivation step
- Ref must refer to an Assertion such as a logic Axiom or a Theorem.
- You can leave Ref blank to allow Unify to figure it out for you.
- Proof Text input reader last position at Line: 8 Column: 1"
+*The nearest nearest theorems to "reiteration" in set.mm are called
+ "dummylink" and "idi". If we used either of them as the "ref", we
+ *would* complete this proof. However, mmj2 avoids using them by default.
+ It's basically not normal to prove something from itself; it's more
+ likely to be a mistake or a special technical use. For example,
+ "dummylink" is a technical theorem used by the Metamath
+ Export/Import tool, eimm.exe, and should not be used in completed
+ proofs. Normally in mmj2 we use the following RunParm to exclude
+ "dummylink" from the set of Assertions that can be automatically
+ used in Unification:
 
- When you see "Proof Text input reader...blah-blah" that tells you that
- the error was so severe that processing stopped immediately. The
- program didn't even attempt Unification.
+     "ProofAsstUnifySearchExclude,biigb,xxxid,dummylink"
 
- An error message would also appear if you used "reiteration.1" instead
- of "wph" in the "qed" step Ref field.
+ This theorem is interesting for several reasons. It has the shortest
+ possible Metamath RPN-format proof, "wph". That is the Label of the
+ Variable Hypothesis statement in set.mm that refers to wff Variable
+ "ph". Another interesting fact is that its proof in Metamath requires
+ no Axioms! That's right. It is a built-in feature of the underlying
+ Metamath proof language: just pop "wph" onto the stack and Q.E.D.!
 
- The problem is that the mmj2 Proof Assistant requires that the Ref
- Label on a Derivation step refer to an Assertion, not a Hypothesis.
- This is a limitation of the mmj2 Proof Assistant, and was intended to
- simplify the programming of mmj2.
+ You might think of setting the "qed" step's Ref = "wph" and pressing
+ Ctrl-U to complete the proof. It turns out that won't work.
+ Try that, and see what happens!
 
  OK, forward to the next Tutorial page (Page404.mmp)!
+
 $)

--- a/mmj2jar/PATutorial/Page403.mmp
+++ b/mmj2jar/PATutorial/Page403.mmp
@@ -1,5 +1,5 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
-*                                                          Page402.mmp
+*                                                          Page403.mmp
 h1::reiteration.1  |- ph
 qed::              |- ph
 

--- a/mmj2jar/PATutorial/Page404.mmp
+++ b/mmj2jar/PATutorial/Page404.mmp
@@ -1,6 +1,17 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
 *                                                          Page404.mmp
- We're going to have to actually prove this theorem in spite of the
+ If we try to use "wph" as qed's Ref, we'll see
+ this error message: "E-PA-0350 Theorem reiteration
+ Step qed: Invalid Ref = wph is not an Assertion. A derivation step
+ Ref must refer to an Assertion such as a logic Axiom or a Theorem.
+ You can leave Ref blank to allow Unify to figure it out for you.
+ Proof Text input reader last position..."
+
+ The error message is hopefully clear:
+ a "Ref" has to be an axiom or previously-proven theorem.
+
+ We're intentionally avoiding the already-existing proofs of this. So
+ we're going to have to actually prove this theorem in spite of the
  fact that it obvious that "If statement A is true then Statement A
  is true".
 
@@ -10,10 +21,7 @@ qed::              |- ph
 *As an experiment, set the "qed" step's Ref = "ax-mp". That means
  the last proof set should be "qed::  |- ph".
  Then press Ctrl-U and see what happens!
- (this is called the "Derive Feature", an integral part of the
- unificiation process in mmj2).
 
  Then proceed to the next Tutorial page (Page405.mmp).
 
 $)
-

--- a/mmj2jar/PATutorial/Page405.mmp
+++ b/mmj2jar/PATutorial/Page405.mmp
@@ -1,13 +1,14 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
 *                                                          Page405.mmp
- Press Ctrl-U and watch the "Derive Feature" in action!
+
+ Press Ctrl-U and watch the unification "Derive Feature" in action!
 
 h1::reiteration.1  |- ph
 !d1::              |- &W1
 !d2::              |- ( &W1 -> ph )
 qed:d1,d2:ax-mp          |- ph
 
-*As we noted earlier, the "Derive feature" is an integral part of mmj2's
+*The "Derive feature" is an integral part of mmj2's
  unification process.  Derive is automatically invoked during unification when
  (1) an assertion Ref label is input on a derivation step
  and fewer Hyp entries are provided than needed for the Ref

--- a/mmj2jar/PATutorial/Page407.mmp
+++ b/mmj2jar/PATutorial/Page407.mmp
@@ -27,7 +27,6 @@ qed:1:ax-mp      |- ph
  with that :-)
 
  OK, you still there? I hope so, because some tremendously useful
- information is available on the next page (Page408.mmp)!!! Do it.
- Ctrl-P now!!!
+ information is available on the next page (Page408.mmp)!
 
 $)

--- a/mmj2jar/PATutorial/Page408.mmp
+++ b/mmj2jar/PATutorial/Page408.mmp
@@ -7,7 +7,7 @@ $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
   Well, to justify "|- ph" a hypothesis is needed because otherwise
   there would have to be a "theorem" using no logical hypotheses
   saying that every wff formula is true. Unlikely... So we believe,
-  right off the bat that an hypothesis is needed for the 'qed' step.
+  right off the bat that a hypothesis is needed for the 'qed' step.
   Right?
 
   So here is "reiteration" again, but now with a "?" in the 'qed'
@@ -16,7 +16,7 @@ $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
 h1::reiteration.1    |- ph
 qed:?:               |- ph
 
-* Now, double-click on the 'qed' step to fire-up the Unify/Step
+* Now, double-click on the 'qed' step to fire up the Unify/Step
   Selector Search which will show us the possible justifications for
   the step (and the resulting expressions if we choose it).
   Note that having the "?" in the Hyps is important.

--- a/mmj2jar/PATutorial/Page409.mmp
+++ b/mmj2jar/PATutorial/Page409.mmp
@@ -4,7 +4,9 @@ $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
 h1::reiteration.1    |- ph
 qed:?:           |- ph
 
-* Double-click on the 'qed' step to fire-up the Unify/Step Selector
+* Now that we know how to start and hide the unify/step selector,
+  let's start it again and *use* it.
+  Double-click on the 'qed' step to fire-up the Unify/Step Selector
   Search. When the Step Selector Dialog window appears, scroll downwards
   until you see "ax-mp", then click on one
   of the ax-mp lines and watch what happens! Wow!!!

--- a/mmj2jar/PATutorial/Page411.mmp
+++ b/mmj2jar/PATutorial/Page411.mmp
@@ -20,18 +20,18 @@ qed:d1,d2:ax-mp  |- ph
   The message that you saw at the bottom should have been something
   like "I-PA-0411 Theorem reiteration: Step d1: Step incomplete.".
   This proof is almost complete! The problem is that step qed
-  depends on d1 and d2, and we haven't justified d2.
-  The hypothesis (step 1) is exactly that form, though;
-  instead of using d1, we should modify qed so it uses step 1 instead.
+  depends on d1 and d2, and we haven't justified d1.
+  The hypothesis (step 1) is exactly the same as d1, though.
+  Instead of using d1, we should modify qed so it uses step 1 instead.
   So all we need to do is change the 'qed' Hyp from "d1,d2" to "1,d2"
   and then press Ctrl-U. Try it! You'll suddenly see a completed proof
   at the bottom (if you can see the bottom), and the message area will say
   "I-PA-0119 Theorem reiteration: RPN-format Metamath proof generated!".
   That means the proof is complete!
 
-* ...Or...there is a short-cut.
+* That said, there is a short-cut.
   Sometimes many other steps refer to an unproven step that should be replaced
-  with some existing step.
+  with some other (possibly proven) step.
   Let's try this out by first pressing control-Z as often as necessary
   to bring us back to the 4-step proof we showed above.
   Now, instead of manually updating the 'qed'

--- a/mmj2jar/PATutorial/Page412.mmp
+++ b/mmj2jar/PATutorial/Page412.mmp
@@ -3,32 +3,35 @@ $( <MM> <PROOF_ASST> THEOREM=QZ LOC_AFTER=
  In the previous "reiteration" proof example we double-clicked the
  'qed' step to invoke the Step Selector Dialog to see all possible
  unifiable Assertions for the 'qed' step. That works great for proving
- "bottom-up", but what about "top-down" proving? Wouldn't it be
- excellent to have a query showing all Assertions which can be unified
- with our Hypotheses? Or any proof step we want to use as an
- Hypothesis to derive another step?
+ backwards from the goal, but what about proving forwards?
+ Wouldn't it be excellent to have a query showing all Assertions which
+ can be unified with our Hypotheses? Or any proof step we want to use
+ as an Hypothesis to derive another step?
 
  It's in there! mmj2 has that feature! Simply combine Work Variable(s)
  with the Step Selector and you have a top-down, bottom-up or even
  middle-out "search matrix"!
 
  In this example -- theorem "QZ" -- double-click any derivation step:
-    - Step 100: find all unifying Assertions using both Hypotheses (a
-      "top down" search);
-    - Step 200...an example of working from the middle out;
+    - Step 100: find all unifying Assertions using both Hypotheses
+      (a "forwards" search);
+    - Step 200: an example of working from the middle out, where
+      we know some of the steps we will use and some of the parts of
+      the result;
     - Step 'qed': find unifying Assertions with 1 or more hypotheses,
-      including step 200 ("bottom up" search).
+      including step 200 ("backwards" search).
 
 h1::QZ.1       |- ( ph -> ( ps -> ch ) )
 h2::QZ.2       |- ( ph -> ( ps -> -. ch ) )
 
-100:1,2:      |- &W1
+100:1,2:
 
 200:2,100,?:  |- ( ( -. ps -> ph ) -> &W2 )
 
 qed:?,200:    |- ( ph -> -. ps )
 
-*As a Pop Quiz, see if you can finish this proof. Then proceed to the
- next page of the Tutorial (Page413.mmp).
+*As a Pop Quiz, see if you can finish this proof.
+ It's okay if you can't do it yet. Then proceed to the
+ next page of the Tutorial (Page501.mmp).
 
 $)

--- a/mmj2jar/PATutorial/Page501.mmp
+++ b/mmj2jar/PATutorial/Page501.mmp
@@ -27,5 +27,7 @@ $( <MM> <PROOF_ASST> THEOREM=95p1e96 LOC_AFTER=
 
 qed:: |- ( ; 9 5 + 1 ) = ; 9 6
 
+* When you're ready, please go on to Page502.mmp.
+
 $)
 

--- a/mmj2jar/PATutorial/Page502.mmp
+++ b/mmj2jar/PATutorial/Page502.mmp
@@ -1,5 +1,5 @@
 $( <MM> <PROOF_ASST> THEOREM=95p1e96 LOC_AFTER=
-*                                                          Page501.mmp
+*                                                          Page502.mmp
 
   If mmj2 is given no reference and no hypotheses, and isn't allowed
   to use its automation capabilities, then unsurprisingly mmj2 can't

--- a/mmj2jar/PATutorial/Page502.mmp
+++ b/mmj2jar/PATutorial/Page502.mmp
@@ -26,25 +26,29 @@ qed:d1,d2,d3,d4:decsuc |- ( ; 9 5 + 1 ) = ; 9 6
   You can also delete the entire left side of the worksheet,
   giving only statements, and it will find refs and link everything together.
 
-  There's an mmj2 automation that you might not have even noticed.
+  There's another mmj2 automation that you might not have even noticed,
+  but it's always enabled even without the '!'.
   If it can, mmj2 unification respects the order of input
-  hypotheses for a derivation proof step... but if the given
+  hypotheses for a derivation proof step. But if the given
   order does not yield a consistent set of variable substitutions for
-  a Ref assertion, the program methodically tests other sequences and
-  dynamically rearranges its input Hyp's. For example, if the user
-  inputs Hyp "10,20,30" referring to previous steps numbered 10, 20, and 30,
-  but the referenced steps do not unify with the Ref's 1st, 2nd, and
-  3rd hypotheses, the program seeks an alternate arrangement, such as
-  "30,10,20". In some cases, there may be multiple satisfactory sequences of
-  hypotheses, so where it matters you should be specific.
-  You do not need to specify everything; if you don't know what some of them
-  are, you can use "?"s in the Hyp subfield.
+  a Ref assertion, then mmj2 methodically tests other sequences and
+  dynamically rearranges its input Hyp's if can find a match.
+  For example, if the user inputs Hyp "10,20,30" referring to previous
+  steps numbered 10, 20, and 30, but the referenced steps do not unify
+  with the Ref's 1st, 2nd, and 3rd hypotheses, the program seeks an
+  alternate arrangement, such as "30,10,20". In some cases, there may
+  be multiple satisfactory sequences of hypotheses, so where it matters
+  you should be specific.  You do not need to specify everything; if you
+  don't know what some of them are, you can use "?"s in the Hyp subfield.
   Thus, using 20,?,10 will cause the system to first try to unify using
   step 20 for the first hypothesis and step 10 for the third hypothesis
   before trying any alternatives.
 
-  Sadly, mmj2's automation facilities are limited (this is true for
-  *all* interactive theorem provers, not just mmj2). So in practice,
+  And finally, as we've just noticed, a leading '!' enables some
+  additional automation, which can save you time.
+
+  Sadly, mmj2's automation facilities are limited. This is true for
+  *all* interactive theorem provers, not just mmj2. So in practice,
   proofs developed with mmj2 are often developed through a
   combination of human direction and automation.
 
@@ -53,6 +57,8 @@ qed:d1,d2,d3,d4:decsuc |- ( ; 9 5 + 1 ) = ; 9 6
   we must prove everything. To write numbers more than 9, we can prefix
   the numbers with one or more ";" (one for each digit beyond the first one),
   followed by the digits themselves.
+
+  Please go on to Page503.mmp.
 
 $=  ( c9 c5 c6 cdc 9nn0 5nn0 5p1e6 eqid decsuc ) ABCABDZEFGJHI $.
 

--- a/mmj2jar/PATutorial/Page503.mmp
+++ b/mmj2jar/PATutorial/Page503.mmp
@@ -1,0 +1,40 @@
+$( <MM> <PROOF_ASST> THEOREM=nngt1ne1REDO  LOC_AFTER=nnge1
+*                                                          Page503.mmp
+
+* A good way to learn how to create Metamath proofs is to
+  study existing (smaller) proofs, then remove little bits and try to
+  reinsert what's missing.
+
+  The "File/Get Proof" option lets you load any existing proof
+  in as a Worksheet. For example, the text below was created
+  by using File/Get Proof on "nngt1ne1", which proves that a positive
+  integer is greater than one iff it is not equal to one.
+
+  The set.mm database has a set of naming conventions that can help you.
+  In most cases, the name of a theorem is a concatentation of
+  "label fragments" of the important part of its conclusion.
+  Each label fragment as a meaning, e.g., "nn" for natural numbers,
+  "re" for real numbers, "1" for the number 1, "gt" for "greater than",
+  "le" for less than, "an" for and, and so on.
+  Most symbols are defined by an assertion named "df-NAME", where
+  NAME is the label fragment used. Note that in set.mm, "natural number"
+  means an integer that is one or larger.
+  Thus, in set.mm, "nnre" represents "the natural numbers are real numbers",
+  and "nnge1" represents "the natural numbers are greater than or equal
+  to 1". For more details, see the set.mm conventions section off the
+  main Metamath Proof Explorer (set.mm) home page.
+
+* A positive integer is greater than one iff it is not equal to one.
+  (Contributed by NM, 7-Oct-2004.)
+
+50::nnre           |- ( A e. NN -> A e. RR )
+51::nnge1          |- ( A e. NN -> 1 <_ A )
+52::1re            |- 1 e. RR
+53::leltne         |- (  ( 1 e. RR /\ A e. RR /\ 1 <_ A )
+                      -> ( 1 < A <-> A =/= 1 ) )
+54:52,53:mp3an1    |- ( ( A e. RR /\ 1 <_ A ) -> ( 1 < A <-> A =/= 1 ) )
+qed:50,51,54:syl2anc 
+                   |- ( A e. NN -> ( 1 < A <-> A =/= 1 ) )
+
+* Please go on to Page901.mmp.
+$)

--- a/mmj2jar/PATutorial/Page901.mmp
+++ b/mmj2jar/PATutorial/Page901.mmp
@@ -1,5 +1,5 @@
 $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
-*                                                          Page413.mmp
+*                                                          Page901.mmp
 
 * This is the end of the (main) tutorial text. For now... but you already
   know enough to be very dangerous :-)
@@ -26,6 +26,9 @@ $( <MM> <PROOF_ASST> THEOREM=reiteration  LOC_AFTER=
   simultaneously! That means that you can switch over to session #2 to
   create a lemma theorem using the Proof Assistant Theorem Loader, and
   then switch back to session #1 and use the new lemma!
+
+  Feel free to look at the "bonus" tutorial page PageLocalRef.mmp
+  to learn more about local references, if you're interested.
 
   In any case, thanks for your time, and we with you
   good luck in developing new proofs.

--- a/mmj2jar/PATutorial/PageLocalRef.mmp
+++ b/mmj2jar/PATutorial/PageLocalRef.mmp
@@ -48,4 +48,3 @@ qed:1002,2002:ax-mp     |- ( ph -> ch )
        execution if an error is found and no changes are made.)
 
 $)
-


### PR DESCRIPTION
Make a large number of changes to the tutorial
so that it now matches the current mmj2 and set.mm.
This also improves the overall flow.

This swaps pages 402 and 403; I think this order
is much easier to understand.

It also adds a new Page503, which explains
"File/Get Proof" and hints a little bit at the
set.mm label naming conventions.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>