### PR TITLE
Fix some nits in the tutorial

### DIFF
--- a/mmj2jar/PATutorial/Page102.mmp
+++ b/mmj2jar/PATutorial/Page102.mmp
@@ -5,7 +5,7 @@ $( <MM> <PROOF_ASST> THEOREM=welcome  LOC_AFTER=a1i
  line that has a non-blank character in column 1 (a blank in column 1,
  or a blank line, indicates continuation of the previous line).
 
- Non-Comment Proof Worksheet Statements are distinguished
+ Proof Worksheet Statements are distinguished
  by specific tokens beginning in column 1:
      - Header ("$(" in line 1 above);
      - Comment ("*")

--- a/mmj2jar/PATutorial/Page201.mmp
+++ b/mmj2jar/PATutorial/Page201.mmp
@@ -9,7 +9,7 @@ qed::         |- ( ph -> ( ph -> ph ) )
  (a statement we can prove from axioms and other provable assertions).
  For our purposes, "theorem" is a synonym for
  "provable assertion". The purpose of mmj2 is to help people create
- proofs of thoerems.
+ proofs of theorems.
 
  In the Header Statement (line 1) we are naming the theorem with
  label "aProofLabel". Since the theorem is new the label name must not

--- a/mmj2jar/PATutorial/Page303.mmp
+++ b/mmj2jar/PATutorial/Page303.mmp
@@ -9,7 +9,7 @@ h30                |- ( ch -> th )
 4:3:               |- ( ( ph -> ps ) -> ( ph -> ch ) )
 qed:1000,4:        |- ( ph -> ch )
 
-*There are two IMPORTANT things to NOTICE in the proof steps above:
+*There are several IMPORTANT things to NOTICE in the proof steps above:
      - Hypothesis Step 30 is redundant. It serves no purpose except
        to make the point: mmj2 and Metamath do not warn the user
        about unused Logical Hypotheses in proofs!

--- a/mmj2jar/PATutorial/Page405.mmp
+++ b/mmj2jar/PATutorial/Page405.mmp
@@ -28,7 +28,7 @@ qed:d1,d2:ax-mp          |- ph
  Since we gave
  Derive no hypotheses and ax-mp uses two hypotheses, Derive generated
  two Hypothesis steps for us that match ax-mp's hypotheses, and filled
- in those hypothses using the information it had available.
+ in those hypotheses using the information it had available.
 
      !d1::            |- &W1
      !d2::            |- ( &W1 -> ph )
@@ -43,7 +43,7 @@ qed:d1,d2:ax-mp          |- ph
  wff variable or expression (work variables are "meta-metavariables").
  You only need to change one instance of a work variable - once you
  change one, then the next time you use control-U, the other
- work variables's values will all be subsituted to match.
+ work variables's values will all be substituted to match.
 
  More generally, the Derive function will produce work variables
  whenever there is insufficient information


### PR DESCRIPTION
While reviewing the mmj2 tutorial video I found a few nits.
This commit fixes them.

I don't think it's necessary to redo the video just for these
nits, but it'd be good to fix them for the future.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>