### PR TITLE
Increase maximum Java memory to 2 Gibibytes

### DIFF
--- a/mmj2jar/mmj2-cygwin.bat
+++ b/mmj2jar/mmj2-cygwin.bat
@@ -4,4 +4,5 @@ rem  cd; git clone https://github.com/metamath/set.mm.git # DB in ~/set.mm/
 rem Then put mmj2 in cygwin's ~/mmj2 . To get the "master" version, use:
 rem  cd; git clone https://github.com/digama0/mmj2.git    # mmj2 in ~/mmj2
 rem Then use Windows "cmd" to run this command (e.g., with a shortcut!)
-java -Xincgc -Xms128M -Xmx512M -jar mmj2.jar RunParms.txt Y "" c:\cygwin64\home\%USERNAME%\set.mm ""
+rem
+java -Xincgc -Xms128M -Xmx2g -jar mmj2.jar RunParms.txt Y "" c:\cygwin64\home\%USERNAME%\set.mm ""

--- a/mmj2jar/mmj2.bat
+++ b/mmj2jar/mmj2.bat
@@ -1,1 +1,1 @@
-java -Xincgc -Xms128M -Xmx512M -jar mmj2.jar RunParms.txt Y "" c:\metamath ""
+java -Xincgc -Xms128m -Xmx2g -jar mmj2.jar RunParms.txt Y "" c:\metamath ""

--- a/mmj2jar/mmj2PATutorial.bat
+++ b/mmj2jar/mmj2PATutorial.bat
@@ -1,1 +1,1 @@
-java -Xincgc -Xms128M -Xmx256M -jar mmj2.jar RunParmsPATutorial.txt Y "" "" ""
+java -Xincgc -Xms128m -Xmx2g -jar mmj2.jar RunParmsPATutorial.txt Y "" "" ""

--- a/mmj2jar/mmj2r.bat
+++ b/mmj2jar/mmj2r.bat
@@ -1,3 +1,3 @@
 :loop
-java -Xincgc -Xms128M -Xmx256M -jar mmj2.jar RunParms.txt Y "" c:\metamath ""
+java -Xincgc -Xms128m -Xmx2g -jar mmj2.jar RunParms.txt Y "" c:\metamath ""
 goto loop


### PR DESCRIPTION
Increase the maximum Java memory to 2 Gibibytes (2G)
when running using the provided Windows batch files.
Without this change, mmj2 can fail on Windows
due to a lack of memory when processing set.mm.

The file set.mm keeps getting bigger, and mmj2
includes an Early parser (which uses more memory),
so the old maximum of 512 Mebibytes (512M)
can lead to failure on startup when processing set.mm.

This commit increases the maximum to 2 Gibibytes.
This seems to be enough to handle set.mm.
This maximum is a strain for 32-bit systems, but such
systems are disappearing, and by the time we might need
to re-raise it I don't expect 32-bit systems to be in
use for this purposes.

This commit does *not* change the starting memory size,
just the maximum, because a user might choose a database
other than set.mm which doesn't require a lot of memory.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>