### PR TITLE
patch for missing transformation crash

### DIFF
--- a/src/mmj/transforms/EquivalenceInfo.java
+++ b/src/mmj/transforms/EquivalenceInfo.java
@@ -76,6 +76,12 @@ public class EquivalenceInfo extends DBInfo {
     {
         assert !fillDeductRules;
         fillDeductRules = true;
+        
+        final Collection<Stmt> implOps = implInfo.getImplForPrefixOperators();
+        for (final Stmt op : implOps) {
+            eqDeductCom.put(op, new HashMap<>());
+            eqDeductTrans.put(op, new HashMap<>());
+        }
 
         for (final Assrt assrt : assrtList)
             findEquivalenceCommutativeDeductionRules(assrt, implInfo);
@@ -83,16 +89,16 @@ public class EquivalenceInfo extends DBInfo {
         for (final Assrt assrt : assrtList)
             findEquivalenceTransitiveDeductionRules(assrt, implInfo);
 
-        final Collection<Stmt> implOps = implInfo.getImplForPrefixOperators();
         for (final Stmt op : implOps) {
             final Map<Stmt, Assrt> dedCom = eqDeductCom.get(op);
             final Map<Stmt, Assrt> dedTrans = eqDeductTrans.get(op);
+            
             for (final Stmt eqOp : eqCommutatives.keySet()) {
-                if (dedCom == null || !dedCom.containsKey(eqOp))
+                if (!dedCom.containsKey(eqOp))
                     output.errorMessage(
                         TrConstants.ERRMSG_MISSING_EQUAL_COMMUT_DEDUCT_RULE, op,
                         eqOp);
-                if (dedTrans == null || !dedTrans.containsKey(eqOp))
+                if (!dedTrans.containsKey(eqOp))
                     output.errorMessage(
                         TrConstants.ERRMSG_MISSING_EQUAL_TRANSIT_DEDUCT_RULE,
                         op, eqOp);

--- a/src/mmj/transforms/EquivalenceInfo.java
+++ b/src/mmj/transforms/EquivalenceInfo.java
@@ -88,11 +88,11 @@ public class EquivalenceInfo extends DBInfo {
             final Map<Stmt, Assrt> dedCom = eqDeductCom.get(op);
             final Map<Stmt, Assrt> dedTrans = eqDeductTrans.get(op);
             for (final Stmt eqOp : eqCommutatives.keySet()) {
-                if (!dedCom.containsKey(eqOp))
+                if (dedCom == null || !dedCom.containsKey(eqOp))
                     output.errorMessage(
                         TrConstants.ERRMSG_MISSING_EQUAL_COMMUT_DEDUCT_RULE, op,
                         eqOp);
-                if (!dedTrans.containsKey(eqOp))
+                if (dedTrans == null || !dedTrans.containsKey(eqOp))
                     output.errorMessage(
                         TrConstants.ERRMSG_MISSING_EQUAL_TRANSIT_DEDUCT_RULE,
                         op, eqOp);


### PR DESCRIPTION
Hasty patch for #48. Just adds a nullity check for `EquivalenceInfo.fillDeductRules()`'s deduction rule detection.