### PR TITLE
complie/posis_compile compatible with macos find

### DIFF
--- a/compile/posix_compile
+++ b/compile/posix_compile
@@ -5,7 +5,7 @@
 #
 echo "Manifest-Version: 1.0" >MANIFEST.MF
 echo "Main-Class: mmj.util.BatchMMJ2" >>MANIFEST.MF
-cd src && javac `find . ../lib -name *.java` -d ../classes && \
+cd src && javac $(find . ../lib -name "*.java") -d ../classes && \
 cd ../classes && \
 jar cfm ../mmj2.jar ../MANIFEST.MF \
-`find -name "*.class" | sed -e "s/^\.\///"`
+$(find . -name "*.class" | sed -e "s/^\.\///")


### PR DESCRIPTION
Upon compilation with macOS, I got the following error:
```
compile/posix_compile*

Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```
It is due to the fact that macOs find is operating a little bit differently.

This PR works well for macOs, but I am not sure about other operating systems